### PR TITLE
Fix towny add player to town effect (fixes #3)

### DIFF
--- a/src/main/java/me/sharpjaws/sharpsk/hooks/Towny/EffTownyAddPlayerToTown.java
+++ b/src/main/java/me/sharpjaws/sharpsk/hooks/Towny/EffTownyAddPlayerToTown.java
@@ -22,6 +22,7 @@ public class EffTownyAddPlayerToTown extends Effect {
     public boolean init(Expression<?>[] expr, int matchedPattern, Kleenean paramKleenean,
                         SkriptParser.ParseResult paramParseResult) {
         p = (Expression<OfflinePlayer>) expr[0];
+        s = (Expression<String>) expr[1];
 
         return true;
     }


### PR DESCRIPTION
Fixes towny add player to town effect giving NullPointerException. The original author forgot to set the expression variable.